### PR TITLE
This change allows the user the ability to simply click on the prorate link to prorate the record without additional navigation.

### DIFF
--- a/AD419.DataHelper.Web/Controllers/PrincipalsController.cs
+++ b/AD419.DataHelper.Web/Controllers/PrincipalsController.cs
@@ -56,7 +56,6 @@ namespace AD419.DataHelper.Web.Controllers
                 return View(match);
             }
 
-
             match.MatchName = name.Name;
 
             DbContext.Entry(match).State = EntityState.Modified;
@@ -65,6 +64,7 @@ namespace AD419.DataHelper.Web.Controllers
             return RedirectToAction("UnproratedMatches");
         }
 
+        [HttpPost]
         public ActionResult ProrateMatch(int id)
         {
             var match = DbContext.PrincipalInvestigatorMatches.Find(id);
@@ -79,20 +79,6 @@ namespace AD419.DataHelper.Web.Controllers
 
             match.IsProrated = true;
 
-            // Adding these lines here allows the user to simply click on the Prorate link to prorate the entry
-            // without the need to navigate to another page.
-            DbContext.Entry(match).State = EntityState.Modified;
-            DbContext.SaveChanges();
-
-            return RedirectToAction("UnproratedMatches");
-            // end added lines
-
-            //return View(match);
-        }
-
-        [HttpPost]
-        public ActionResult ProrateMatch(PrincipalInvestigatorMatch match)
-        {
             DbContext.Entry(match).State = EntityState.Modified;
             DbContext.SaveChanges();
 

--- a/AD419.DataHelper.Web/Views/Principals/UnproratedMatches.cshtml
+++ b/AD419.DataHelper.Web/Views/Principals/UnproratedMatches.cshtml
@@ -51,7 +51,12 @@
                     @Html.ActionLink("Match", "FindMatch", new { id = item.Id })
                 </td>
                 <td>
-                    @Html.ActionLink("Prorate", "ProrateMatch", new { id = item.Id })
+                    @using (Html.BeginForm("ProrateMatch", "Principals", FormMethod.Post, new { id = "ProrateForm", enctype = "multipart/form-data", @class = "" }))
+                    {
+                        @Html.AntiForgeryToken()
+                        @Html.Hidden("id", item.Id)
+                        <input type="submit" class="btn-link" value="Prorate" />
+                    }
                 </td>
             </tr>
         }


### PR DESCRIPTION
@srkirkland : This a quick and dirty fix to minimize the amount of mouse clicks the user needs to prorate an entry.
