### PR TITLE
Increased Status controller's database timeout from 5 to 15 minutes as reports take nearly 12 minuted to run.

### DIFF
--- a/AD419.DataHelper.Web/Controllers/StatusController.cs
+++ b/AD419.DataHelper.Web/Controllers/StatusController.cs
@@ -78,7 +78,7 @@ namespace AD419.DataHelper.Web.Controllers
             SqlParameter param1 = new SqlParameter("@FiscalYear", year);
             SqlParameter param2 = new SqlParameter("@IsDebug", false);
 
-            DbContext.Database.CommandTimeout = 60*15; // 15 minute timeout, are reports take about 12 minutes to run.
+            DbContext.Database.CommandTimeout = 60*15; // 15 minute timeout, as reports take about 12 minutes to run.
             DbContext.Database.ExecuteSqlCommand(string.Format("{0} @FiscalYear, @IsDebug", sprocName), param1, param2);
             DbContext.Database.CommandTimeout = null;
         }        


### PR DESCRIPTION
@srkirkland: This will allow the reports to be run from the UI without timing out.
