### PR TITLE
Removed <li>@Html.ActionLink("SFN 204 Award Number Exclusions", "Index", "C204Exclusions")</li> from _topNav.cthtml as per issue #114.

### DIFF
--- a/AD419.DataHelper.Web/Views/Shared/_TopNav.cshtml
+++ b/AD419.DataHelper.Web/Views/Shared/_TopNav.cshtml
@@ -33,7 +33,6 @@
                         <li>@Html.ActionLink("Annual Report Codes", "Index", "ArcCodes")</li>
                         <li>@Html.ActionLink("ARC/Account Exclusions", "Index", "ArcCodeAccountExclusions")</li>
                         <li>@Html.ActionLink("Project Maintenance", "Index", "AllProjectsNew")</li>
-                        <li>@Html.ActionLink("SFN 204 Award Number Exclusions", "Index", "C204Exclusions")</li>
                         <li>@Html.ActionLink("Non-204 Expired Project Cross Reference", "Index", "ExpiredProjects")</li>
                         <li>@Html.ActionLink("204-20x Project Mappings", "Index", "ProjectMapping")</li>
                         <li>@Html.ActionLink("DOS Codes", "Index", "DosCodes")</li>


### PR DESCRIPTION
@srkirkland: Addresses issue #114 .
Please review.