### PR TITLE
Kjt 20171122 reenableabliltytoinsertfieldstationexpensesafterupload

### DIFF
--- a/AD419.DataHelper.Web/AD419.DataHelper.Web.csproj
+++ b/AD419.DataHelper.Web/AD419.DataHelper.Web.csproj
@@ -245,6 +245,7 @@
     <Compile Include="Controllers\ExpiredProjectsController.cs" />
     <Compile Include="Controllers\FinalReportsController.cs" />
     <Compile Include="Controllers\Ad419InstructionsController.cs" />
+    <Compile Include="Helpers\ProcessCategoryExtensions.cs" />
     <Compile Include="Services\SelfCertifyingTitleCodesService.cs" />
     <Compile Include="Controllers\TitlesController.cs" />
     <Compile Include="Models\SelfCertifyingTitleCode.cs" />

--- a/AD419.DataHelper.Web/Controllers/CesListImportController.cs
+++ b/AD419.DataHelper.Web/Controllers/CesListImportController.cs
@@ -109,6 +109,14 @@ namespace AD419.DataHelper.Web.Controllers
 
             DbContext.Database.ExecuteSqlCommand("TRUNCATE TABLE CesListImport");
 
+            // 1. Use the hard-coded status Id to reset ProcessStatus.IsCompleted.
+            DbContext.ClearStatusCompleted(ProcessStatuses.ImportCeSpecialists);
+
+            // 2. Get it's categoryID and reset ProcessCategory.IsCompleted to false.
+            DbContext.ClearCategoryCompleted(ProcessStatuses.ImportCeSpecialists);
+
+            DbContext.SaveChanges();
+
             return RedirectToAction("Index");
         }
 
@@ -185,6 +193,13 @@ namespace AD419.DataHelper.Web.Controllers
                 {
                     DbContext.CesListImports.AddRange(cesEntries);
                     DbContext.MarkStatusCompleted(ProcessStatuses.ImportCeSpecialists);
+                    DbContext.MarkCategoryCompleted(ProcessStatuses.ImportCeSpecialists);
+
+                    // We also need to clear the next category and process so that they 
+                    // can be re-inserted in the expenses table as the new values.
+                    DbContext.ClearStatusCompletedForNextCategory(ProcessStatuses.ImportCeSpecialists);
+                    DbContext.ClearCategoryCompletedForNextCategory(ProcessStatuses.ImportCeSpecialists);
+
                     DbContext.SaveChanges();
                 }
                 else

--- a/AD419.DataHelper.Web/Controllers/FieldStationExpensesImportController.cs
+++ b/AD419.DataHelper.Web/Controllers/FieldStationExpensesImportController.cs
@@ -112,7 +112,7 @@ namespace AD419.DataHelper.Web.Controllers
             //                                     "Where Id = " + ProcessStatuses.ImportFieldStationExpenses);
 
             // 1. Use the hard-coded status Id to reset ProcessStatus.IsCompleted.
-            DbContext.ClearStatusCompleted((ProcessStatuses.ImportFieldStationExpenses);
+            DbContext.ClearStatusCompleted(ProcessStatuses.ImportFieldStationExpenses);
            
             // 2. Get it's categoryID and reset ProcessCategory.IsCompleted to false.
 

--- a/AD419.DataHelper.Web/Controllers/FieldStationExpensesImportController.cs
+++ b/AD419.DataHelper.Web/Controllers/FieldStationExpensesImportController.cs
@@ -107,6 +107,25 @@ namespace AD419.DataHelper.Web.Controllers
 
             DbContext.Database.ExecuteSqlCommand("TRUNCATE TABLE FieldStationExpenseListImport");
 
+            //DbContext.Database.ExecuteSqlCommand("Update ProcessStatus " +
+            //                                     "Set IsCompleted = 0  " +
+            //                                     "Where Id = " + ProcessStatuses.ImportFieldStationExpenses);
+
+            // 1. Use the hard-coded status Id to reset ProcessStatus.IsCompleted.
+            DbContext.ClearStatusCompleted((ProcessStatuses.ImportFieldStationExpenses);
+           
+            // 2. Get it's categoryID and reset ProcessCategory.IsCompleted to false.
+
+            //DbContext.Database.ExecuteSqlCommand("Update ProcessCategory " +
+            //                                     "Set IsCompleted = 0 " +
+            //                                     "From ProcessCategory t1 " +
+            //                                     "Inner Join ProcessStatus t2 ON t1.Id = t2.CategoryId " +
+            //                                     "Where t2.Id = " + ProcessStatuses.ImportFieldStationExpenses);
+
+             DbContext.ClearCategoryCompleted(ProcessStatuses.ImportFieldStationExpenses);
+
+             DbContext.SaveChanges();
+
             return RedirectToAction("Index");
         }
 
@@ -183,6 +202,13 @@ namespace AD419.DataHelper.Web.Controllers
                 {
                     DbContext.FieldStationExpenseListImports.AddRange(fieldStationExpenseEntries);
                     DbContext.MarkStatusCompleted(ProcessStatuses.ImportFieldStationExpenses);
+                    DbContext.MarkCategoryCompleted(ProcessStatuses.ImportFieldStationExpenses);
+
+                    // We also need to clear the next category and process so that they 
+                    // can be re-inserted in the expenses table as the new values.
+                    DbContext.ClearStatusCompletedForNextCategory(ProcessStatuses.ImportFieldStationExpenses);
+                    DbContext.ClearCategoryCompletedForNextCategory(ProcessStatuses.ImportFieldStationExpenses);
+
                     DbContext.SaveChanges();
                 }
                 else

--- a/AD419.DataHelper.Web/Helpers/ProcessCategoryExtensions.cs
+++ b/AD419.DataHelper.Web/Helpers/ProcessCategoryExtensions.cs
@@ -8,10 +8,10 @@ namespace AD419.DataHelper.Web.Helpers
     {
         public static ProcessCategory GetProcessCategory(this AD419DataContext context, ProcessStatuses status)
         {
+            // returns the process status for the given ID
             var processStatus = ProcessStatusExtensions.GetProcessStatus(context, status);
 
-            var processCategory =
-                context.ProcessCategories.FirstOrDefault(c => c.Statuses.FirstOrDefault().Equals(processStatus));
+            var processCategory = context.ProcessCategories.FirstOrDefault(c => c.Id == processStatus.CategoryId);
 
             if (processCategory == null)
             {
@@ -26,7 +26,7 @@ namespace AD419.DataHelper.Web.Helpers
         {
             var processCategory = GetProcessCategory(context, status);
 
-            var nextProcessCategory = context.ProcessCategories.FirstOrDefault(c => c.SequenceOrder.Equals(processCategory.SequenceOrder + 1));
+            var nextProcessCategory = context.ProcessCategories.FirstOrDefault(c => c.SequenceOrder == (processCategory.SequenceOrder + 1));
 
             if (nextProcessCategory == null)
             {

--- a/AD419.DataHelper.Web/Helpers/ProcessCategoryExtensions.cs
+++ b/AD419.DataHelper.Web/Helpers/ProcessCategoryExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data.Entity;
 using System.Linq;
 using AD419.DataHelper.Web.Models;
 
@@ -26,7 +27,8 @@ namespace AD419.DataHelper.Web.Helpers
         {
             var processCategory = GetProcessCategory(context, status);
 
-            var nextProcessCategory = context.ProcessCategories.FirstOrDefault(c => c.SequenceOrder == (processCategory.SequenceOrder + 1));
+            var nextProcessCategory = context.ProcessCategories.Where(c => c.SequenceOrder == processCategory.SequenceOrder + 1).
+                Include(c => c.Statuses).FirstOrDefault();
 
             if (nextProcessCategory == null)
             {

--- a/AD419.DataHelper.Web/Helpers/ProcessCategoryExtensions.cs
+++ b/AD419.DataHelper.Web/Helpers/ProcessCategoryExtensions.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Linq;
+using AD419.DataHelper.Web.Models;
+
+namespace AD419.DataHelper.Web.Helpers
+{
+    public static class ProcessCategoryExtensions
+    {
+        public static ProcessCategory GetProcessCategory(this AD419DataContext context, ProcessStatuses status)
+        {
+            var processStatus = ProcessStatusExtensions.GetProcessStatus(context, status);
+
+            var processCategory =
+                context.ProcessCategories.FirstOrDefault(c => c.Statuses.FirstOrDefault().Equals(processStatus));
+
+            if (processCategory == null)
+            {
+                throw new ArgumentException(string.Format("Could not find process category for process status {0}",
+                    status));
+            }
+
+            return processCategory;
+        }
+
+        public static ProcessCategory GetNextProcessCategory(this AD419DataContext context, ProcessStatuses status)
+        {
+            var processCategory = GetProcessCategory(context, status);
+
+            var nextProcessCategory = context.ProcessCategories.FirstOrDefault(c => c.SequenceOrder.Equals(processCategory.SequenceOrder + 1));
+
+            if (nextProcessCategory == null)
+            {
+                throw new ArgumentException(string.Format("Could not find next process category for process status {0}", status));
+            }
+
+            return nextProcessCategory;
+        }
+
+        // Mark category as completed
+        public static void MarkCategoryCompleted(this AD419DataContext context, ProcessStatuses status)
+        {
+            var processCategory = GetProcessCategory(context, status);
+
+            processCategory.IsCompleted = true;
+        }
+
+        public static void ClearCategoryCompleted(this AD419DataContext context, ProcessStatuses status)
+        {
+            var processCategory = GetProcessCategory(context, status);
+
+            processCategory.IsCompleted = false;
+        }
+
+        public static void ClearCategoryCompletedForNextCategory(this AD419DataContext context, ProcessStatuses status)
+        {
+            var nextProcessCategory = GetNextProcessCategory(context, status);
+
+            nextProcessCategory.IsCompleted = false;
+        }
+    }
+}

--- a/AD419.DataHelper.Web/Helpers/ProcessStatusExtensions.cs
+++ b/AD419.DataHelper.Web/Helpers/ProcessStatusExtensions.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Web;
 using AD419.DataHelper.Web.Models;
 
 namespace AD419.DataHelper.Web.Helpers
 {
     public static class ProcessStatusExtensions
     {
-        // Mark process as completed
-        public static void MarkStatusCompleted(this AD419DataContext context, ProcessStatuses status)
+        public static AD419.DataHelper.Web.Models.ProcessStatus GetProcessStatus(AD419DataContext context, ProcessStatuses status)
         {
             var processStatus = context.ProcessStatuses.Find((int)status);
 
@@ -18,7 +15,34 @@ namespace AD419.DataHelper.Web.Helpers
                 throw new ArgumentException(string.Format("Could not find process status for {0}", status));
             }
 
+            return processStatus;
+        }
+
+        // Mark process as completed
+        public static void MarkStatusCompleted(this AD419DataContext context, ProcessStatuses status)
+        {
+            var processStatus = GetProcessStatus(context, status);
+
             processStatus.IsCompleted = true;
+        }
+
+        public static void ClearStatusCompleted(this AD419DataContext context, ProcessStatuses status)
+        {
+            var processStatus = GetProcessStatus(context, status);
+
+            processStatus.IsCompleted = false;
+        }
+
+        public static void ClearStatusCompletedForNextCategory(this AD419DataContext context, ProcessStatuses status)
+        {
+            var nextProcessStatus = context.GetNextProcessCategory(status).Statuses.FirstOrDefault();
+
+            if (nextProcessStatus == null)
+            {
+                throw new ArgumentException(string.Format("Could not find next process status for {0}", status));
+            }
+
+            nextProcessStatus.IsCompleted = false;
         }
     }
 }

--- a/AD419.DataHelper.Web/Helpers/ProcessStatusExtensions.cs
+++ b/AD419.DataHelper.Web/Helpers/ProcessStatusExtensions.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 using System.Linq;
 using AD419.DataHelper.Web.Models;
+using WebGrease.Css.Extensions;
 
 namespace AD419.DataHelper.Web.Helpers
 {
     public static class ProcessStatusExtensions
     {
-        public static AD419.DataHelper.Web.Models.ProcessStatus GetProcessStatus(AD419DataContext context, ProcessStatuses status)
+        public static AD419.DataHelper.Web.Models.ProcessStatus GetProcessStatus(AD419DataContext context,
+            ProcessStatuses status)
         {
-            var processStatus = context.ProcessStatuses.Find((int)status);
+            var processStatus = context.ProcessStatuses.Find((int) status);
 
             if (processStatus == null)
             {
@@ -37,8 +39,7 @@ namespace AD419.DataHelper.Web.Helpers
         {
             var nextProcessCategory = context.GetNextProcessCategory(status);
 
-            var nextProcessStatuses =
-                context.ProcessStatuses.Where(s => s.CategoryId == nextProcessCategory.Id);
+            var nextProcessStatuses = nextProcessCategory.Statuses;
 
             if (nextProcessStatuses == null)
             {
@@ -46,10 +47,9 @@ namespace AD419.DataHelper.Web.Helpers
             }
 
             // Because there may be more than just a single process status to clear.
-            foreach (var nextProcessStatus in nextProcessStatuses)
-            {
-                nextProcessStatus.IsCompleted = false;
-            }
+            //nextProcessStatuses.ForEach(n => n.IsCompleted = false);
+            //nextProcessStatuses.All(c => { c.IsCompleted = false; return true; });
+            nextProcessStatuses.Select(c => { c.IsCompleted = false; return c; }).ToList();
         }
     }
 }

--- a/AD419.DataHelper.Web/Helpers/ProcessStatusExtensions.cs
+++ b/AD419.DataHelper.Web/Helpers/ProcessStatusExtensions.cs
@@ -37,15 +37,19 @@ namespace AD419.DataHelper.Web.Helpers
         {
             var nextProcessCategory = context.GetNextProcessCategory(status);
 
-            var nextProcessStatus =
-                context.ProcessStatuses.FirstOrDefault(s => s.CategoryId == nextProcessCategory.Id);
+            var nextProcessStatuses =
+                context.ProcessStatuses.Where(s => s.CategoryId == nextProcessCategory.Id);
 
-            if (nextProcessStatus == null)
+            if (nextProcessStatuses == null)
             {
-                throw new ArgumentException(string.Format("Could not find next process status for {0}", status));
+                throw new ArgumentException(string.Format("Could not find next process status(es) for {0}", status));
             }
 
-            nextProcessStatus.IsCompleted = false;
+            // Because there may be more than just a single process status to clear.
+            foreach (var nextProcessStatus in nextProcessStatuses)
+            {
+                nextProcessStatus.IsCompleted = false;
+            }
         }
     }
 }

--- a/AD419.DataHelper.Web/Helpers/ProcessStatusExtensions.cs
+++ b/AD419.DataHelper.Web/Helpers/ProcessStatusExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using AD419.DataHelper.Web.Models;
-using WebGrease.Css.Extensions;
 
 namespace AD419.DataHelper.Web.Helpers
 {

--- a/AD419.DataHelper.Web/Helpers/ProcessStatusExtensions.cs
+++ b/AD419.DataHelper.Web/Helpers/ProcessStatusExtensions.cs
@@ -35,7 +35,10 @@ namespace AD419.DataHelper.Web.Helpers
 
         public static void ClearStatusCompletedForNextCategory(this AD419DataContext context, ProcessStatuses status)
         {
-            var nextProcessStatus = context.GetNextProcessCategory(status).Statuses.FirstOrDefault();
+            var nextProcessCategory = context.GetNextProcessCategory(status);
+
+            var nextProcessStatus =
+                context.ProcessStatuses.FirstOrDefault(s => s.CategoryId == nextProcessCategory.Id);
 
             if (nextProcessStatus == null)
             {

--- a/AD419.DataHelper.Web/Web.config
+++ b/AD419.DataHelper.Web/Web.config
@@ -10,13 +10,14 @@
   </configSections>
   <connectionStrings>
     <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\v11.0;AttachDbFilename=|DataDirectory|\aspnet-AD-419_DataHelperWebApp-20160217015628.mdf;Initial Catalog=aspnet-AD-419_DataHelperWebApp-20160217015628;Integrated Security=True" providerName="System.Data.SqlClient" />
-    <!--<add name="AD419DataContext" connectionString="data source=terry.caes.ucdavis.edu;initial catalog=AD419;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+    <add name="AD419DataContext" connectionString="data source=terry.caes.ucdavis.edu;initial catalog=AD419;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
     <add name="FISDataContext" connectionString="data source=terry.caes.ucdavis.edu;initial catalog=FISDataMart;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-    <add name="CatbertDataContext" connectionString="data source=terry.caes.ucdavis.edu;initial catalog=Catbert3;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />-->
-	  <add name="AD419DataContext" connectionString="data source=donbot.caes.ucdavis.edu;initial catalog=AD419;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+    <add name="CatbertDataContext" connectionString="data source=terry.caes.ucdavis.edu;initial catalog=Catbert3;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+	  <!--<add name="AD419DataContext" connectionString="data source=donbot.caes.ucdavis.edu;initial catalog=AD419;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
 	  <add name="FISDataContext" connectionString="data source=donbot.caes.ucdavis.edu;initial catalog=FISDataMart;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-	  <add name="CatbertDataContext" connectionString="data source=donbot.caes.ucdavis.edu;initial catalog=Catbert3;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-    <add name="PpsDataContext" connectionString="data source=tinnytim;initial catalog=PPSDataMart;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
+	  <add name="CatbertDataContext" connectionString="data source=donbot.caes.ucdavis.edu;initial catalog=Catbert3;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />-->
+    <!--<add name="PpsDataContext" connectionString="data source=tinnytim;initial catalog=PPSDataMart;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />-->
+    <add name="PpsDataContext" connectionString="data source=terry;initial catalog=PPSDataMart;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings file="AppSettings.config">
     <add key="webpages:Version" value="3.0.0.0" />


### PR DESCRIPTION
For CE Specialists and Field Station Expenses:
1. Delete All now resets the status and category for the corresponding import step.
2. Upon successful import and save, the current category is marked completed, and the next category and status(es) are cleared so that the new (or reloaded) records can be transferred into the expenses table.  Without adding this logic, new records could only be imported, but not actually be transferred into expenses. Meaning, the previous values would remain as there was no way to re-load them into expenses from the UI, since that step had already been marked as completed. 