### PR TITLE
Update AD419AccountController.cs

### DIFF
--- a/AD419.DataHelper.Web/Controllers/AD419AccountController.cs
+++ b/AD419.DataHelper.Web/Controllers/AD419AccountController.cs
@@ -85,7 +85,7 @@ namespace AD419.DataHelper.Web.Controllers
                 return HttpNotFound();
             }
 
-            if (myAd419Account.OrgR.Equals(accountWithTheWrongClosedOrg.CurrentOrgR))
+            if (aD419Account.OrgR.Equals(accountWithTheWrongClosedOrg.CurrentOrgR))
             {
                 // Then just set the flag to indicate that the account has been reviewed
                 myAd419Account.HaveOrgsBeenAdjusted = false;


### PR DESCRIPTION
Fixed comaparison issue, which was using the incorrect object to determine if an Org had been updated.