### PR TITLE
Added Report Server Authentication logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,4 @@ packages/
 AppSettings.config
 AD419.DataHelper.Web/AD419.DataHelper.Web.csproj.DotSettings
 AD419.DataHelper.Web/Web.Release.config
+AD419.DataHelper.Web/connectionStrings.config

--- a/AD419.DataHelper.Web/AD419.DataHelper.Web.csproj
+++ b/AD419.DataHelper.Web/AD419.DataHelper.Web.csproj
@@ -113,7 +113,7 @@
     </Reference>
     <Reference Include="Microsoft.ReportViewer.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Windows\assembly\GAC_MSIL\Microsoft.ReportViewer.Common\11.0.0.0__89845dcd8080cc91\Microsoft.ReportViewer.Common.dll</HintPath>
+      <HintPath>bin\Microsoft.ReportViewer.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ReportViewer.DataVisualization, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -422,6 +422,9 @@
     <Content Include="Content\Sample_Forms\TitleCodesSelfCertify.xlsx" />
     <Content Include="Content\Sample_Forms\NifaProjectAndAccessionNumberImport.xlsx" />
     <Content Include="Instructions\AD419Instructions.pdf" />
+    <Content Include="connectionStrings.config" />
+    <Content Include="appSettings.config" />
+    <None Include="Properties\PublishProfiles\AD419DataHelper - Web Deploy.pubxml" />
     <None Include="Properties\PublishProfiles\Release.pubxml" />
     <None Include="Properties\PublishProfiles\test.pubxml" />
     <None Include="Scripts\jquery-2.2.4.intellisense.js" />
@@ -445,11 +448,13 @@
     <Content Include="Scripts\upload-wizard.js" />
     <Content Include="Scripts\_references.js" />
     <Content Include="Views\AssociatedTotalsBySfnReport\Index.cshtml" />
-    <None Include="Web.config">
+    <Content Include="Web.config">
       <SubType>Designer</SubType>
-    </None>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Content Include="Views\Web.config" />
     <Content Include="Views\_ViewStart.cshtml" />
@@ -641,6 +646,14 @@
     <Content Include="Views\ProjectOrgAssociationsPercentageReport\Index.cshtml" />
     <Content Include="Views\Unassociated241EmployeeExpenseReport\Index.cshtml" />
     <Content Include="Views\NonAdminPreReport\Index.cshtml" />
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Web.Test.config">
+      <DependentUpon>Web.config</DependentUpon>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/AD419.DataHelper.Web/Models/ReportViewerModel.cs
+++ b/AD419.DataHelper.Web/Models/ReportViewerModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Configuration;
+using System.Net;
 using System.Web.UI.WebControls;
 using Microsoft.Reporting.WebForms;
 
@@ -9,6 +10,10 @@ namespace AD419.DataHelper.Web.Models
     {
         private static readonly string ReportServerUrl = ConfigurationManager.AppSettings["ReportServerUrl"];
         private static readonly string ReportServerDirectory = ConfigurationManager.AppSettings["ReportServerDirectory"];
+        private static readonly string ReportViewerUserName = ConfigurationManager.AppSettings["ReportViewerUser"]; 
+        private static readonly string ReportViewerPassword = ConfigurationManager.AppSettings["ReportViewerPassword"];
+        private static readonly string ReportViewerDomainName = ConfigurationManager.AppSettings["ReportViewerDomain"];
+
         public string ReportPath { get; set; }
 
         public ReportViewer ReportViewer { get; set; }
@@ -34,7 +39,43 @@ namespace AD419.DataHelper.Web.Models
                 ProcessingMode = ProcessingMode.Remote
             };
 
-            ReportViewer.ServerReport.ReportServerUrl = new Uri(ReportServerUrl);
+           IReportServerCredentials myCredentials = new CustomReportCredentials(ReportViewerUserName, ReportViewerPassword, ReportViewerDomainName);
+           ReportViewer.ServerReport.ReportServerCredentials = myCredentials;
+           ReportViewer.ServerReport.ReportServerUrl = new Uri(ReportServerUrl);
+            
+        }
+
+        public class CustomReportCredentials : IReportServerCredentials
+        {
+            private string _userName;
+            private string _passWord;
+            private string _domainName;
+
+            public CustomReportCredentials(string userName, string passWord, string domainName)
+            {
+                _userName = userName;
+                _passWord = passWord;
+                _domainName = domainName;
+            }
+
+            public System.Security.Principal.WindowsIdentity ImpersonationUser
+            {
+                get { return null; }
+            }
+
+            public ICredentials NetworkCredentials
+            {
+                get { return new NetworkCredential(_userName, _passWord, _domainName); }
+            }
+
+            public bool GetFormsCredentials(out Cookie authCookie, out string user, out string password,
+                out string authority)
+            {
+                authCookie = null;
+                user = password = authority = null;
+                return false;
+            }
+
         }
     }
 }

--- a/AD419.DataHelper.Web/Properties/ServiceDependencies/AD419DataHelper - Web Deploy/profile.arm.json
+++ b/AD419.DataHelper.Web/Properties/ServiceDependencies/AD419DataHelper - Web Deploy/profile.arm.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_dependencyType": "appService.windows"
+  },
+  "parameters": {
+    "resourceGroupName": {
+      "type": "string",
+      "defaultValue": "AD419",
+      "metadata": {
+        "description": "Name of the resource group for the resource. It is recommended to put resources under same resource group for better tracking."
+      }
+    },
+    "resourceGroupLocation": {
+      "type": "string",
+      "defaultValue": "westus2",
+      "metadata": {
+        "description": "Location of the resource group. Resource groups could have different location than resources, however by default we use API versions from latest hybrid profile which support all locations for resource types we support."
+      }
+    },
+    "resourceName": {
+      "type": "string",
+      "defaultValue": "AD419DataHelper",
+      "metadata": {
+        "description": "Name of the main resource to be created by this template."
+      }
+    },
+    "resourceLocation": {
+      "type": "string",
+      "defaultValue": "[parameters('resourceGroupLocation')]",
+      "metadata": {
+        "description": "Location of the resource. By default use resource group's location, unless the resource provider is not supported there."
+      }
+    }
+  },
+  "variables": {
+    "appServicePlan_name": "[concat('Plan', uniqueString(concat(parameters('resourceName'), subscription().subscriptionId)))]",
+    "appServicePlan_ResourceId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('resourceGroupName'), '/providers/Microsoft.Web/serverFarms/', variables('appServicePlan_name'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[parameters('resourceGroupLocation')]",
+      "apiVersion": "2019-10-01"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(parameters('resourceGroupName'), 'Deployment', uniqueString(concat(parameters('resourceName'), subscription().subscriptionId)))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "apiVersion": "2019-10-01",
+      "dependsOn": [
+        "[parameters('resourceGroupName')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [
+            {
+              "location": "[parameters('resourceLocation')]",
+              "name": "[parameters('resourceName')]",
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2015-08-01",
+              "tags": {
+                "[concat('hidden-related:', variables('appServicePlan_ResourceId'))]": "empty"
+              },
+              "dependsOn": [
+                "[variables('appServicePlan_ResourceId')]"
+              ],
+              "kind": "app",
+              "properties": {
+                "name": "[parameters('resourceName')]",
+                "kind": "app",
+                "httpsOnly": true,
+                "reserved": false,
+                "serverFarmId": "[variables('appServicePlan_ResourceId')]",
+                "siteConfig": {
+                  "metadata": [
+                    {
+                      "name": "CURRENT_STACK",
+                      "value": "dotnetcore"
+                    }
+                  ]
+                }
+              },
+              "identity": {
+                "type": "SystemAssigned"
+              }
+            },
+            {
+              "location": "[parameters('resourceLocation')]",
+              "name": "[variables('appServicePlan_name')]",
+              "type": "Microsoft.Web/serverFarms",
+              "apiVersion": "2015-08-01",
+              "sku": {
+                "name": "S1",
+                "tier": "Standard",
+                "family": "S",
+                "size": "S1"
+              },
+              "properties": {
+                "name": "[variables('appServicePlan_name')]"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/AD419.DataHelper.Web/Views/Web.config
+++ b/AD419.DataHelper.Web/Views/Web.config
@@ -1,35 +1,41 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 
 <configuration>
   <configSections>
-    <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
-      <section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
-      <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+    <sectionGroup name="system.web.webPages.razor"
+      type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+      <section name="host"
+        type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"
+        requirePermission="false"/>
+      <section name="pages"
+        type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"
+        requirePermission="false"/>
     </sectionGroup>
   </configSections>
 
   <system.web.webPages.razor>
-    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"/>
     <pages pageBaseType="System.Web.Mvc.WebViewPage">
       <namespaces>
-        <add namespace="System.Web.Mvc" />
-        <add namespace="System.Web.Mvc.Ajax" />
-        <add namespace="System.Web.Mvc.Html" />
+        <add namespace="System.Web.Mvc"/>
+        <add namespace="System.Web.Mvc.Ajax"/>
+        <add namespace="System.Web.Mvc.Html"/>
         <add namespace="System.Web.Optimization"/>
-        <add namespace="System.Web.Routing" />
-        <add namespace="AD419.DataHelper.Web" />
+        <add namespace="System.Web.Routing"/>
+        <add namespace="AD419.DataHelper.Web"/>
       </namespaces>
     </pages>
   </system.web.webPages.razor>
 
   <appSettings>
-    <add key="webpages:Enabled" value="false" />
+    <add key="webpages:Enabled" value="false"/>
   </appSettings>
 
   <system.webServer>
     <handlers>
       <remove name="BlockViewHandler"/>
-      <add name="BlockViewHandler" path="*" verb="*" preCondition="integratedMode" type="System.Web.HttpNotFoundHandler" />
+      <add name="BlockViewHandler" path="*" verb="*" preCondition="integratedMode" type="System.Web.HttpNotFoundHandler"/>
     </handlers>
   </system.webServer>
+
 </configuration>

--- a/AD419.DataHelper.Web/Web.Test.config
+++ b/AD419.DataHelper.Web/Web.Test.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/AD419.DataHelper.Web/Web.config
+++ b/AD419.DataHelper.Web/Web.config
@@ -8,20 +8,12 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
-  <connectionStrings>
-    <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\v11.0;AttachDbFilename=|DataDirectory|\aspnet-AD-419_DataHelperWebApp-20160217015628.mdf;Initial Catalog=aspnet-AD-419_DataHelperWebApp-20160217015628;Integrated Security=True" providerName="System.Data.SqlClient" />
-    <!--<add name="AD419DataContext" connectionString="data source=terry.caes.ucdavis.edu;initial catalog=AD419;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-    <add name="FISDataContext" connectionString="data source=terry.caes.ucdavis.edu;initial catalog=FISDataMart;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-    <add name="CatbertDataContext" connectionString="data source=terry.caes.ucdavis.edu;initial catalog=Catbert3;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />-->
-	  <!--<add name="AD419DataContext" connectionString="data source=donbot.caes.ucdavis.edu;initial catalog=AD419;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />-->
-    <add name="AD419DataContext" connectionString="data source=caes-donbot.ou.ad3.ucdavis.edu;initial catalog=AD419;User ID=ProdAppAD419;Password=X0TDZWogArdJwSOnsqYO;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-	  <add name="FISDataContext" connectionString="data source=caes-elzar;initial catalog=FISDataMart;User ID=ProdAppAD419;Password=X0TDZWogArdJwSOnsqYO;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-	  <add name="CatbertDataContext" connectionString="data source=caes-donbot.ou.ad3.ucdavis.edu;initial catalog=Catbert3;User ID=ProdAppAD419;Password=X0TDZWogArdJwSOnsqYO;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-    <!--<add name="PpsDataContext" connectionString="data source=caes-elzar;initial catalog=PPSDataMart;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />-->
-    <add name="PpsDataContext" connectionString="data source=caes-elzar;initial catalog=PPSDataMart;User ID=ProdAppAD419;Password=X0TDZWogArdJwSOnsqYO;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
-    <!--<add name="PpsDataContext" connectionString="data source=terry.caes.ucdavis.edu;initial catalog=PPSDataMart;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />-->
-  </connectionStrings>
+
+  <connectionStrings configSource="connectionStrings.config"/>
+
   <appSettings file="AppSettings.config">
+    <!--<appSettings>-->
+
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
@@ -31,7 +23,7 @@
     <add key="Stackify.ApiKey" value="[external]" />
     <!--<add key="ReportServerUrl" value="http://testreports.caes.ucdavis.edu/ReportServer/" />
     <add key="AD419AppUrl" value="https://test.caes.ucdavis.edu/AD419" />-->
-    <add key="ReportServerUrl" value="http://reports.caes.ucdavis.edu/ReportServer/" />
+    <add key="ReportServerUrl" value="http://caes-reports/ReportServer" />
     <add key="AD419AppUrl" value="https://AD419.caes.ucdavis.edu/" />
     <add key="ReportServerDirectory" value="/AD419Reports/" />
     <add key="InstructionsDirectory" value="~/Instructions" />


### PR DESCRIPTION
Required implementation of class for interface IReportServerCredentials.  This allows authentication for the report data's return trip when the webserver and the report server are on different domains, i.e. Azure, and campus.